### PR TITLE
Added support for compound catch blocks.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,17 +16,25 @@
     </properties>
 
     <dependencies>
+        <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.8.2</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>1.18.24</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
@@ -37,6 +45,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>
@@ -51,6 +60,10 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M6</version>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,13 @@
 
     <groupId>io.github.jadefalke</groupId>
     <artifactId>Try-Catch</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/src/main/java/io/github/jadefalke2/CompoundCatchClause.java
+++ b/src/main/java/io/github/jadefalke2/CompoundCatchClause.java
@@ -1,0 +1,36 @@
+package io.github.jadefalke2;
+
+import io.github.jadefalke2.interfaces.CatchClause;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Consumer;
+
+/**
+ * A catch clause that maps many exception types to a single consumer.
+ */
+public class CompoundCatchClause implements CatchClause {
+    private final Set<Class<? extends Exception>> exceptionTypes;
+    private final Consumer<? super Exception> consumer;
+
+    public CompoundCatchClause(Collection<Class<? extends Exception>> exceptionTypes, Consumer<? super Exception> consumer) {
+        this.exceptionTypes = new HashSet<>(exceptionTypes);
+        this.consumer = consumer;
+    }
+
+    @SafeVarargs
+    public CompoundCatchClause(Consumer<? super Exception> consumer, Class<? extends Exception>... exceptionTypes) {
+        this(Set.of(exceptionTypes), consumer);
+    }
+
+    @Override
+    public Collection<Class<? extends Exception>> exceptionTypes() {
+        return exceptionTypes;
+    }
+
+    @Override
+    public Consumer<? super Exception> consumer() {
+        return consumer;
+    }
+}

--- a/src/main/java/io/github/jadefalke2/CompoundCatchClause.java
+++ b/src/main/java/io/github/jadefalke2/CompoundCatchClause.java
@@ -15,6 +15,7 @@ public class CompoundCatchClause implements CatchClause {
     private final Consumer<? super Exception> consumer;
 
     public CompoundCatchClause(Collection<Class<? extends Exception>> exceptionTypes, Consumer<? super Exception> consumer) {
+        checkTypes(exceptionTypes);
         this.exceptionTypes = new HashSet<>(exceptionTypes);
         this.consumer = consumer;
     }
@@ -32,5 +33,26 @@ public class CompoundCatchClause implements CatchClause {
     @Override
     public Consumer<? super Exception> consumer() {
         return consumer;
+    }
+
+    /**
+     * Checks that the given exception types are valid for a compound catch
+     * clause. That is, all the types must not be subtypes of each other.
+     * @param exceptionTypes The exception types to check.
+     * @throws IllegalArgumentException If some types are invalid.
+     */
+    private void checkTypes(Collection<Class<? extends Exception>> exceptionTypes) throws IllegalArgumentException {
+        for (var typeA : exceptionTypes) {
+            for (var typeB : exceptionTypes) {
+                if (typeA == typeB) continue;
+                if (typeA.isAssignableFrom(typeB) || typeB.isAssignableFrom(typeA)) {
+                    throw new IllegalArgumentException(String.format(
+                            "%s and %s may not both be caught by the same compound catch clause.",
+                            typeA.getSimpleName(),
+                            typeB.getSimpleName()
+                    ));
+                }
+            }
+        }
     }
 }

--- a/src/main/java/io/github/jadefalke2/SingleCatchClause.java
+++ b/src/main/java/io/github/jadefalke2/SingleCatchClause.java
@@ -14,7 +14,7 @@ public class SingleCatchClause<T extends Exception> implements CatchClause {
     private final Class<T> exceptionType;
     private final Consumer<? super T> consumer;
 
-    public SingleCatchClause(Class<T> exceptionType, Consumer<T> consumer) {
+    public SingleCatchClause(Class<T> exceptionType, Consumer<? super T> consumer) {
         this.exceptionType = exceptionType;
         this.consumer = consumer;
     }

--- a/src/main/java/io/github/jadefalke2/SingleCatchClause.java
+++ b/src/main/java/io/github/jadefalke2/SingleCatchClause.java
@@ -1,0 +1,32 @@
+package io.github.jadefalke2;
+
+import io.github.jadefalke2.interfaces.CatchClause;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.function.Consumer;
+
+/**
+ * A catch clause that handles a single type of exception.
+ * @param <T> The type of exception to handle.
+ */
+public class SingleCatchClause<T extends Exception> implements CatchClause {
+    private final Class<T> exceptionType;
+    private final Consumer<? super T> consumer;
+
+    public SingleCatchClause(Class<T> exceptionType, Consumer<T> consumer) {
+        this.exceptionType = exceptionType;
+        this.consumer = consumer;
+    }
+
+    @Override
+    public Collection<Class<? extends Exception>> exceptionTypes() {
+        return Set.of(exceptionType);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Consumer<? super Exception> consumer() {
+        return (Consumer<? super Exception>) consumer;
+    }
+}

--- a/src/main/java/io/github/jadefalke2/Try.java
+++ b/src/main/java/io/github/jadefalke2/Try.java
@@ -83,7 +83,7 @@ public class Try <T, Ex extends Exception> implements TryBuilder.CatchBuilder<T>
      * @return This builder object.
      */
     @Override
-    public CatchBuilder<T> onCatch(@NonNull Consumer<Exception> onCatch) {
+    public CatchBuilder<T> onCatch(@NonNull Consumer<? super Exception> onCatch) {
         addCatchClause(new SingleCatchClause<>(Exception.class, onCatch));
         return this;
     }
@@ -96,7 +96,7 @@ public class Try <T, Ex extends Exception> implements TryBuilder.CatchBuilder<T>
      * @param <E> The exception type.
      */
     @Override
-    public <E extends Exception> CatchBuilder<T> onCatch(@NonNull Class<E> exceptionType, @NonNull Consumer<E> onCatch) {
+    public <E extends Exception> CatchBuilder<T> onCatch(@NonNull Class<E> exceptionType, @NonNull Consumer<? super E> onCatch) {
         addCatchClause(new SingleCatchClause<>(exceptionType, onCatch));
         return this;
     }
@@ -108,7 +108,7 @@ public class Try <T, Ex extends Exception> implements TryBuilder.CatchBuilder<T>
      * @return This builder object.
      */
     @Override
-    public CatchBuilder<T> onCatch(@NonNull Collection<Class<? extends Exception>> exceptionTypes, @NonNull Consumer<Exception> onCatch) {
+    public CatchBuilder<T> onCatch(@NonNull Collection<Class<? extends Exception>> exceptionTypes, @NonNull Consumer<? super Exception> onCatch) {
         addCatchClause(new CompoundCatchClause(exceptionTypes, onCatch));
         return this;
     }

--- a/src/main/java/io/github/jadefalke2/Try.java
+++ b/src/main/java/io/github/jadefalke2/Try.java
@@ -1,12 +1,14 @@
 package io.github.jadefalke2;
 
-import io.github.jadefalke2.exceptions.CatchBlockAlreadyExistsException;
+import io.github.jadefalke2.exceptions.CatchClauseAlreadyExistsException;
+import io.github.jadefalke2.interfaces.CatchClause;
 import io.github.jadefalke2.interfaces.UnsafeRunnable;
 import io.github.jadefalke2.interfaces.UnsafeSupplier;
 import lombok.NonNull;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -18,7 +20,7 @@ import java.util.function.Consumer;
 public class Try <T, Ex extends Exception> implements TryBuilder.CatchBuilder<T>, TryBuilder<T> {
 
     private final UnsafeSupplier<Ex, T> attempt;
-    private final Map<Class<? extends Exception>, Consumer<? super Exception>> catchClauses;
+    private final List<CatchClause> catchClauses;
     private Runnable onFinally;
 
     /**
@@ -27,7 +29,7 @@ public class Try <T, Ex extends Exception> implements TryBuilder.CatchBuilder<T>
      */
     private Try (UnsafeSupplier<Ex, T> attempt) {
         this.attempt = attempt;
-        catchClauses = new HashMap<>();
+        catchClauses = new LinkedList<>();
     }
 
     /**
@@ -53,27 +55,62 @@ public class Try <T, Ex extends Exception> implements TryBuilder.CatchBuilder<T>
     }
 
     /**
-     * Appends a catch-block with the given type
-     * @param exceptionType the type of exception
-     * @param onCatch the code to run when this catch block is executed
-     * @return the try instance
+     * Internal method to add a catch clause to this builder. This checks that
+     * we don't already have a catch clause that is eligible to accept any
+     * exception type that the new clause handles.
+     * @param clause The catch clause to add.
+     * @throws CatchClauseAlreadyExistsException If the given clause handles
+     * exceptions that are already handled by catch clauses that have been
+     * previously added to this builder.
      */
-    @SuppressWarnings("unchecked")
-    public <E extends Exception> TryBuilder.CatchBuilder<T> onCatch (@NonNull Class<E> exceptionType,
-                                                                     @NonNull Consumer<? super E> onCatch) {
-        if (catchClauses.containsKey(exceptionType))
-            throw new CatchBlockAlreadyExistsException();
-        catchClauses.put(exceptionType, (Consumer<? super Exception>) onCatch);
+    private void addCatchClause(CatchClause clause) throws CatchClauseAlreadyExistsException {
+        for (var existingClause : catchClauses) {
+            for (var type : clause.exceptionTypes()) {
+                for (var existingType : existingClause.exceptionTypes()) {
+                    if (existingType.equals(type)) {
+                        throw new CatchClauseAlreadyExistsException(existingType, existingClause);
+                    }
+                }
+            }
+        }
+        catchClauses.add(clause);
+    }
+
+    /**
+     * Adds a catch clause that is called to handle any exception thrown when
+     * this try is run.
+     * @param onCatch The consumer to handle exceptions.
+     * @return This builder object.
+     */
+    @Override
+    public CatchBuilder<T> onCatch(@NonNull Consumer<Exception> onCatch) {
+        addCatchClause(new SingleCatchClause<>(Exception.class, onCatch));
         return this;
     }
 
     /**
-     * Appends a catch-block with the Exception type
-     * @param onCatch the code to run when this catch block is executed
-     * @return the try instance
+     * Adds a catch clause to handle a specific type of exception.
+     * @param exceptionType The type of exception.
+     * @param onCatch The consumer to handle exceptions.
+     * @return This builder object.
+     * @param <E> The exception type.
      */
-    public TryBuilder.CatchBuilder<T> onCatch (@NonNull Consumer<? super Exception> onCatch) {
-        return onCatch(Exception.class, onCatch);
+    @Override
+    public <E extends Exception> CatchBuilder<T> onCatch(@NonNull Class<E> exceptionType, @NonNull Consumer<E> onCatch) {
+        addCatchClause(new SingleCatchClause<>(exceptionType, onCatch));
+        return this;
+    }
+
+    /**
+     * Adds a catch clause to handle a collection of specific exceptions.
+     * @param exceptionTypes The types of exceptions to handle.
+     * @param onCatch The consumer to handle exceptions.
+     * @return This builder object.
+     */
+    @Override
+    public CatchBuilder<T> onCatch(@NonNull Collection<Class<? extends Exception>> exceptionTypes, @NonNull Consumer<Exception> onCatch) {
+        addCatchClause(new CompoundCatchClause(exceptionTypes, onCatch));
+        return this;
     }
 
     /**
@@ -81,6 +118,7 @@ public class Try <T, Ex extends Exception> implements TryBuilder.CatchBuilder<T>
      * @param onFinally the code run to run in the finally-block
      * @return the try instance
      */
+    @Override
     public TryBuilder<T> onFinally (@NonNull Runnable onFinally) {
         this.onFinally = onFinally;
         return this;
@@ -90,6 +128,7 @@ public class Try <T, Ex extends Exception> implements TryBuilder.CatchBuilder<T>
      * Executes the code in the try-block, catching with the respective catch-block in case an Exception.
      * Finally, whatever branch is executed prior the finally-block will be executed.
      */
+    @Override
     public void run () {
         obtain();
     }
@@ -99,6 +138,7 @@ public class Try <T, Ex extends Exception> implements TryBuilder.CatchBuilder<T>
      * Finally, whatever branch is executed prior the finally-block will be executed.
      * @return the Optional describing the value obtained within the try-catch block
      */
+    @Override
     public Optional<T> obtain () {
         Optional<T> val = Optional.empty();
         try {
@@ -122,20 +162,20 @@ public class Try <T, Ex extends Exception> implements TryBuilder.CatchBuilder<T>
         return CompletableFuture.supplyAsync(this::obtain);
     }
 
-
     /**
      * Gets the correct catch clause for the given class
      * @param c the Exception class
      * @return the optional Exception from the map
      */
     private Optional<Consumer<? super Exception>> getCatchClause (Class<?> c) {
-        if (catchClauses.containsKey(c)) {
-            return Optional.of(catchClauses.get(c));
-        } else {
-            if (c.getSuperclass().equals(Exception.class) || catchClauses.isEmpty()) {
-                return Optional.empty();
+        for (var clause : catchClauses) {
+            if (clause.exceptionTypes().contains(c)) {
+                return Optional.of(clause.consumer());
             }
-            return getCatchClause(c.getSuperclass());
         }
+        if (c.getSuperclass().equals(Exception.class) || catchClauses.isEmpty()) {
+            return Optional.empty();
+        }
+        return getCatchClause(c.getSuperclass());
     }
 }

--- a/src/main/java/io/github/jadefalke2/TryBuilder.java
+++ b/src/main/java/io/github/jadefalke2/TryBuilder.java
@@ -16,16 +16,16 @@ public interface TryBuilder <T> {
 	CompletableFuture<Optional<T>> obtainLater();
 
 	interface CatchBuilder <T> extends TryBuilder<T> {
-		CatchBuilder<T> onCatch(@NonNull Consumer<Exception> onCatch);
+		CatchBuilder<T> onCatch(@NonNull Consumer<? super Exception> onCatch);
 
 		<E extends Exception> CatchBuilder<T> onCatch(
 				@NonNull Class<E> exceptionType,
-				@NonNull Consumer<E> onCatch
+				@NonNull Consumer<? super E> onCatch
 		);
 
 		CatchBuilder<T> onCatch(
 				@NonNull Collection<Class<? extends Exception>> exceptionTypes,
-				@NonNull Consumer<Exception> onCatch
+				@NonNull Consumer<? super Exception> onCatch
 		);
 
 		TryBuilder<T> onFinally (Runnable runnable);

--- a/src/main/java/io/github/jadefalke2/TryBuilder.java
+++ b/src/main/java/io/github/jadefalke2/TryBuilder.java
@@ -3,6 +3,7 @@ package io.github.jadefalke2;
 
 import lombok.NonNull;
 
+import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -15,12 +16,16 @@ public interface TryBuilder <T> {
 	CompletableFuture<Optional<T>> obtainLater();
 
 	interface CatchBuilder <T> extends TryBuilder<T> {
+		CatchBuilder<T> onCatch(@NonNull Consumer<Exception> onCatch);
+
 		<E extends Exception> CatchBuilder<T> onCatch(
-			@NonNull Class<E> exceptionType, @NonNull Consumer<? super E> onCatch
+				@NonNull Class<E> exceptionType,
+				@NonNull Consumer<E> onCatch
 		);
 
 		CatchBuilder<T> onCatch(
-			@NonNull Consumer<? super  Exception> onCatch
+				@NonNull Collection<Class<? extends Exception>> exceptionTypes,
+				@NonNull Consumer<Exception> onCatch
 		);
 
 		TryBuilder<T> onFinally (Runnable runnable);

--- a/src/main/java/io/github/jadefalke2/exceptions/CatchBlockAlreadyExistsException.java
+++ b/src/main/java/io/github/jadefalke2/exceptions/CatchBlockAlreadyExistsException.java
@@ -1,5 +1,0 @@
-package io.github.jadefalke2.exceptions;
-
-public class CatchBlockAlreadyExistsException extends RuntimeException {
-
-}

--- a/src/main/java/io/github/jadefalke2/exceptions/CatchClauseAlreadyExistsException.java
+++ b/src/main/java/io/github/jadefalke2/exceptions/CatchClauseAlreadyExistsException.java
@@ -1,0 +1,22 @@
+package io.github.jadefalke2.exceptions;
+
+import io.github.jadefalke2.interfaces.CatchClause;
+
+public class CatchClauseAlreadyExistsException extends RuntimeException {
+    private final Class<? extends Exception> handledType;
+    private final CatchClause clause;
+
+    public CatchClauseAlreadyExistsException(Class<? extends Exception> handledType, CatchClause clause) {
+        super(String.format("Catch clause already exists because another clause handles exceptions of type %s.", handledType.getSimpleName()));
+        this.handledType = handledType;
+        this.clause = clause;
+    }
+
+    public Class<? extends Exception> getHandledType() {
+        return handledType;
+    }
+
+    public CatchClause getClause() {
+        return clause;
+    }
+}

--- a/src/main/java/io/github/jadefalke2/interfaces/CatchClause.java
+++ b/src/main/java/io/github/jadefalke2/interfaces/CatchClause.java
@@ -1,0 +1,23 @@
+package io.github.jadefalke2.interfaces;
+
+import java.util.Collection;
+import java.util.function.Consumer;
+
+/**
+ * A catch clause declares a collection of exception types which it can handle,
+ * and a consumer that can be called upon to handle any of the given types of
+ * exceptions.
+ */
+public interface CatchClause {
+    /**
+     * Gets the exception types which this catch clause can handle.
+     * @return The collection of exception types which this catch clause can handle.
+     */
+    Collection<Class<? extends Exception>> exceptionTypes();
+
+    /**
+     * Gets the consumer that can be used to handle exceptions.
+     * @return The consumer that can be used to handle exceptions.
+     */
+    Consumer<? super Exception> consumer();
+}

--- a/src/test/java/APITest.java
+++ b/src/test/java/APITest.java
@@ -1,12 +1,14 @@
 import io.github.jadefalke2.Try;
-import io.github.jadefalke2.exceptions.CatchBlockAlreadyExistsException;
+import io.github.jadefalke2.exceptions.CatchClauseAlreadyExistsException;
 import io.github.jadefalke2.interfaces.UnsafeRunnable;
 import io.github.jadefalke2.interfaces.UnsafeSupplier;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
@@ -24,7 +26,7 @@ public class APITest {
 
     @Test
     public void testMultipleCatchBlocks () {
-        assertThrows(CatchBlockAlreadyExistsException.class,
+        assertThrows(CatchClauseAlreadyExistsException.class,
                 () -> Try.attempt(() -> System.out.println("Test"))
                         .onCatch(RuntimeException.class, Throwable::printStackTrace)
                         .onCatch(RuntimeException.class, e -> System.out.println(e.getMessage()))
@@ -45,6 +47,13 @@ public class APITest {
         AtomicBoolean done = new AtomicBoolean(false);
         Try.attempt(() -> {throw new Exception();})
                 .onCatch(e -> done.set(true))
+                .run();
+        assertTrue(done.get());
+
+        // Check that we correctly handle compound catch clauses.
+        done.set(false);
+        Try.attempt(() -> {throw new IOException();})
+                .onCatch(Set.of(IOException.class, FileNotFoundException.class), e -> done.set(true))
                 .run();
         assertTrue(done.get());
     }

--- a/src/test/java/io/github/jadefalke2/APITest.java
+++ b/src/test/java/io/github/jadefalke2/APITest.java
@@ -1,11 +1,11 @@
-import io.github.jadefalke2.Try;
+package io.github.jadefalke2;
+
 import io.github.jadefalke2.exceptions.CatchClauseAlreadyExistsException;
 import io.github.jadefalke2.interfaces.UnsafeRunnable;
 import io.github.jadefalke2.interfaces.UnsafeSupplier;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -13,13 +13,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class APITest {
 
     private AtomicBoolean done;
 
-    @Before
+    @BeforeEach
     public void setUp () {
         done = new AtomicBoolean(false);
     }
@@ -53,7 +53,7 @@ public class APITest {
         // Check that we correctly handle compound catch clauses.
         done.set(false);
         Try.attempt(() -> {throw new IOException();})
-                .onCatch(Set.of(IOException.class, FileNotFoundException.class), e -> done.set(true))
+                .onCatch(Set.of(IOException.class, RuntimeException.class), e -> done.set(true))
                 .run();
         assertTrue(done.get());
     }

--- a/src/test/java/io/github/jadefalke2/CompoundCatchClauseTest.java
+++ b/src/test/java/io/github/jadefalke2/CompoundCatchClauseTest.java
@@ -1,0 +1,30 @@
+package io.github.jadefalke2;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Test for the {@link CompoundCatchClause}
+ */
+public class CompoundCatchClauseTest {
+	/**
+	 * Tests the correctness of the constructor(s), specifically with regard to
+	 * ensuring that invalid exception types are rejected.
+	 */
+	@Test
+	public void testConstruct() {
+		// First test valid cases. No exception should be thrown.
+		new CompoundCatchClause(Throwable::printStackTrace, ArithmeticException.class, IOException.class);
+		new CompoundCatchClause(Throwable::printStackTrace, RuntimeException.class, InterruptedException.class);
+		// Then test invalid cases.
+		assertThrows(IllegalArgumentException.class, () -> {
+			new CompoundCatchClause(Throwable::printStackTrace, Exception.class, IOException.class);
+		});
+		assertThrows(IllegalArgumentException.class, () -> {
+			new CompoundCatchClause(Throwable::printStackTrace, IllegalArgumentException.class, RuntimeException.class);
+		});
+	}
+}


### PR DESCRIPTION
Because actual catch blocks can be of the following form:
```java
try {
    // do something
} catch (IOException | DateTimeParseException e) {
    e.printStackTrace();
}
```
I thought it would be nice to add support for this in your library.